### PR TITLE
Add backend instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Backend Setup
+
+Follow these steps to get the API running:
+
+1. Install dependencies from the `backend` directory:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the server using Node (or the provided npm script):
+
+   ```bash
+   node index.js
+   # or
+   npm start
+   ```
+
+Running `npm install` ensures packages like `express` are available so you won't encounter "Cannot find module 'express'" errors when launching the backend.

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add README to backend with steps for installing dependencies and starting server
- fix package.json syntax so npm scripts work

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_683f700e455083319e1d0355f81799ad